### PR TITLE
update logback version to 1.2.3

### DIFF
--- a/capture-all/logging.mod
+++ b/capture-all/logging.mod
@@ -25,8 +25,8 @@ http://central.maven.org/maven2/org/slf4j/slf4j-api/1.6.6/slf4j-api-1.6.6.jar|li
 http://central.maven.org/maven2/org/slf4j/log4j-over-slf4j/1.6.6/log4j-over-slf4j-1.6.6.jar|lib/logging/log4j-over-slf4j-1.6.6.jar
 http://central.maven.org/maven2/org/slf4j/jul-to-slf4j/1.6.6/jul-to-slf4j-1.6.6.jar|lib/logging/jul-to-slf4j-1.6.6.jar
 http://central.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.6.6/jcl-over-slf4j-1.6.6.jar|lib/logging/jcl-over-slf4j-1.6.6.jar
-http://central.maven.org/maven2/ch/qos/logback/logback-core/1.0.7/logback-core-1.0.7.jar|lib/logging/logback-core-1.0.7.jar
-http://central.maven.org/maven2/ch/qos/logback/logback-classic/1.0.7/logback-classic-1.0.7.jar|lib/logging/logback-classic-1.0.7.jar
+http://central.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar|lib/logging/logback-core-1.2.3.jar
+http://central.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar|lib/logging/logback-classic-1.2.3.jar
 https://raw.githubusercontent.com/jetty-project/logging-modules/master/capture-all/logback.xml|resources/logback.xml
 https://raw.githubusercontent.com/jetty-project/logging-modules/master/capture-all/jetty-logging.properties|resources/jetty-logging.properties
 https://raw.githubusercontent.com/jetty-project/logging-modules/master/capture-all/jetty-logging.xml|etc/jetty-logging.xml

--- a/logback/logging.mod
+++ b/logback/logging.mod
@@ -15,8 +15,8 @@ lib/logging/*.jar
 [files]
 logs/
 http://central.maven.org/maven2/org/slf4j/slf4j-api/1.6.6/slf4j-api-1.6.6.jar|lib/logging/slf4j-api-1.6.6.jar
-http://central.maven.org/maven2/ch/qos/logback/logback-core/1.0.7/logback-core-1.0.7.jar|lib/logging/logback-core-1.0.7.jar
-http://central.maven.org/maven2/ch/qos/logback/logback-classic/1.0.7/logback-classic-1.0.7.jar|lib/logging/logback-classic-1.0.7.jar
+http://central.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar|lib/logging/logback-core-1.2.3.jar
+http://central.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar|lib/logging/logback-classic-1.2.3.jar
 https://raw.githubusercontent.com/jetty-project/logging-modules/master/logback/logback.xml|resources/logback.xml
 https://raw.githubusercontent.com/jetty-project/logging-modules/master/logback/jetty-logging.properties|resources/jetty-logging.properties
 


### PR DESCRIPTION
logback version < 1.2.0 has a security vulnerability. This pull request fixes it by updating the version

See Release notes for 1.2.0 for more details https://logback.qos.ch/news.html